### PR TITLE
Move optionalDependencies to devDependencies and update README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![last commit](https://img.shields.io/github/last-commit/tiagosiebler/bybit-api)][1]
 [![CodeFactor](https://www.codefactor.io/repository/github/tiagosiebler/bybit-api/badge)](https://www.codefactor.io/repository/github/tiagosiebler/bybit-api)
 [![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/bybit-api)
 
 <p align="center">
   <a href="https://www.npmjs.com/package/bybit-api">

--- a/package.json
+++ b/package.json
@@ -39,6 +39,12 @@
     "eslint-plugin-require-extensions": "^0.1.3",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.7.0",
+<<<<<<< Updated upstream
+=======
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.3",
+>>>>>>> Stashed changes
     "source-map-loader": "^2.0.0",
     "ts-jest": "^29.1.2",
     "ts-loader": "^8.0.11",

--- a/package.json
+++ b/package.json
@@ -39,12 +39,6 @@
     "eslint-plugin-require-extensions": "^0.1.3",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "jest": "^29.7.0",
-<<<<<<< Updated upstream
-=======
-    "ts-jest": "^29.1.2",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.7.3",
->>>>>>> Stashed changes
     "source-map-loader": "^2.0.0",
     "ts-jest": "^29.1.2",
     "ts-loader": "^8.0.11",


### PR DESCRIPTION
## Summary
- Move webpack-related optionalDependencies into devDependencies where applicable
- Bump patch version when package.json dependencies changed
- Add Ask DeepWiki badge to README

## Test plan
- [ ] CI passes
- [ ] `npm i` succeeds locally